### PR TITLE
check to see if item is in ignore list from popping

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,10 @@ CHANGES
 --------------------
 
 - Added support for IDict Widget in MultiWidget.
+- Catch bug where if a select value was set as from hidden input 
+  or through a rest url as a single value, it won't error out
+  when trying to remove from ignored list. Probably not the 100%
+  right fix but it catches core dumps and is sane anyways.
 
 
 3.0.0a3 (2013-04-08)

--- a/src/z3c/form/browser/select.py
+++ b/src/z3c/form/browser/select.py
@@ -70,7 +70,7 @@ class SelectWidget(widget.HTMLSelectWidget, SequenceWidget):
 
         def addItem(idx, term, prefix=''):
             selected = self.isSelected(term)
-            if selected:
+            if selected and term.token in ignored:
                 ignored.remove(term.token)
             id = '%s-%s%i' % (self.id, prefix, idx)
             content = term.token


### PR DESCRIPTION
This is from integration, which likely won't affect most people but its a harmless check either way. Just make sure we don't throw a key error wet set(self.value) parses a string instead of whatever it actually expected for that
