### PR TITLE
Added a consistent id on single and multiple checkbox widget.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 3.1.1 (unreleased)
 ------------------
 
-- Added a consistent id on single checkbox widget.
+- Added a consistent id on single checkbox and multi checkbox widgets.
 
 3.1.0 (2013-12-02)
 ------------------

--- a/src/z3c/form/browser/README.txt
+++ b/src/z3c/form/browser/README.txt
@@ -202,7 +202,8 @@ For the boolean, the checkbox widget can be used as well:
   >>> widget.update()
 
   >>> print(widget.render())
-  <span class="option">
+  <span id="foo">
+   <span class="option">
     <input type="checkbox" id="foo-0" name="bar:list"
            class="checkbox-widget required bool-field" value="true"
            checked="checked" />
@@ -215,6 +216,7 @@ For the boolean, the checkbox widget can be used as well:
     <label for="foo-1">
       <span class="label">no</span>
     </label>
+   </span>
   </span>
   <input name="bar-empty-marker" type="hidden" value="1" />
 

--- a/src/z3c/form/browser/checkbox.txt
+++ b/src/z3c/form/browser/checkbox.txt
@@ -73,7 +73,8 @@ Now let's try if we get widget values:
 
   >>> widget.update()
   >>> print(widget.render())
-  <span class="option">
+  <span id="widget-id">
+   <span class="option">
     <input type="checkbox" id="widget-id-0" name="widget.name:list"
            class="checkbox-widget" value="true" />
     <label for="widget-id-0">
@@ -85,6 +86,7 @@ Now let's try if we get widget values:
     <label for="widget-id-1">
       <span class="label">no</span>
     </label>
+   </span>
   </span>
   <input name="widget.name-empty-marker" type="hidden" value="1" />
 
@@ -94,7 +96,8 @@ field get rendered with a checked flag:
   >>> widget.value = 'true'
   >>> widget.update()
   >>> print(widget.render())
-  <span class="option">
+  <span id="widget-id">
+   <span class="option">
     <input type="checkbox" id="widget-id-0" name="widget.name:list"
            class="checkbox-widget" value="true"
            checked="checked" />
@@ -107,6 +110,7 @@ field get rendered with a checked flag:
     <label for="widget-id-1">
       <span class="label">no</span>
     </label>
+   </span>
   </span>
   <input name="widget.name-empty-marker" type="hidden" value="1" />
 
@@ -294,7 +298,8 @@ Check if a term which __str__ returns non ascii string does not crash the update
   >>> print(widget.render())
   <html>
     <body>
-      <span class="option">
+      <span id="widget-id">
+       <span class="option">
         <input class="checkbox-widget" id="widget-id-0" name="widget.name:list" type="checkbox" value="one">
         <label for="widget-id-0">
           <span class="label">One</span>
@@ -305,6 +310,7 @@ Check if a term which __str__ returns non ascii string does not crash the update
         <label for="widget-id-1">
           <span class="label">Two</span>
         </label>
+       </span>
       </span>
       <input name="widget.name-empty-marker" type="hidden" value="1">
     </body>

--- a/src/z3c/form/browser/checkbox_input.pt
+++ b/src/z3c/form/browser/checkbox_input.pt
@@ -1,10 +1,14 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
      xmlns:tal="http://xml.zope.org/namespaces/tal"
      tal:omit-tag=""
-     tal:define="items view/items">
-<span class="option"
-      tal:repeat="item items"
-      tal:attributes="id python:len(items) == 1 and view.id or None">
+     tal:define="items view/items;
+                 single_checkbox python:len(items) == 1">
+<span tal:attributes="id view/id"
+      tal:omit-tag="single_checkbox"
+      tal:condition="python:len(items) > 0">
+ <span class="option"
+       tal:repeat="item items"
+       tal:attributes="id python:single_checkbox and view.id or None">
   <input type="checkbox" id="" name="" class="" alt="" title=""
          tabindex="" disabled="" readonly="" accesskey="" value=""
          checked="checked"
@@ -69,6 +73,7 @@
          tal:attributes="for item/id">
     <span class="label" tal:content="item/label">Label</span>
   </label>
+ </span>
 </span>
 <input name="field-empty-marker" type="hidden" value="1"
        tal:attributes="name string:${view/name}-empty-marker" />


### PR DESCRIPTION
Checkbox widget do not have an id for now. For consistency, this pull request adds an id on the option container (for single widget) and adds a container for all options (for  multiple widget). This may not be the better way, please give me your opinion.
