### PR TITLE
Change javascript for updating ordered select widget hidden structure

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ CHANGES
 3.2.9 (unreleased)
 ------------------
 
+- Change javascript for updating ordered select widget hidden structure so it
+  works again on IE11 and doesn't send back an empty list that deletes all
+  selections on save. Fixes https://github.com/zopefoundation/z3c.form/issues/23
+  [fredvd]
+
 - Started on Dutch translations.
   [maurits]
 

--- a/src/z3c/form/browser/orderedselect_input.js
+++ b/src/z3c/form/browser/orderedselect_input.js
@@ -108,17 +108,9 @@ function copyDataForSubmit(name)
     {
     // create virtual node with suitable attributes
     var newNode = document.createElement("input");
-    var newAttr = document.createAttribute("name");
-    newAttr.nodeValue = name.replace(/-/g, '.')+':list';
-    newNode.setAttributeNode(newAttr);
-
-    newAttr = document.createAttribute("type");
-    newAttr.nodeValue = "hidden";
-    newNode.setAttributeNode(newAttr);
-
-    newAttr = document.createAttribute("value");
-    newAttr.nodeValue = toSel.options[i].value;
-    newNode.setAttributeNode(newAttr);
+    newNode.setAttribute("name", name.replace(/-/g, '.')+':list');
+    newNode.setAttribute("type", "hidden");
+    newNode.setAttribute("value",toSel.options[i].value );
 
     // actually append virtual node to DOM tree
     toDataContainer.appendChild(newNode);


### PR DESCRIPTION
...  so it works again on IE11 and doesn't send back an empty list that deletes all selections on save. Fixes https://github.com/zopefoundation/z3c.form/issues/23