### PR TITLE
Smaller fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ CHANGES
 
 - RadioWidget items are better determined when they are needed [agroszer]
 
+- CheckBoxWidget items are better determined when they are needed [agroszer]
+
 
 3.2.9 (2016-02-01)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ CHANGES
 
 - CheckBoxWidget items are better determined when they are needed [agroszer]
 
+- Bugfix: The ``ChoiceTerms`` adapter blindly assumed that the passed in field
+  is unbound, which is not necessarily the case in interesting ObjectWidget
+  scenarios. Not it checks for a non-None field context first. [srichter]
 
 3.2.9 (2016-02-01)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 3.2.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- RadioWidget items are better determined when they are needed [agroszer]
 
 
 3.2.9 (2016-02-01)

--- a/src/z3c/form/browser/checkbox.py
+++ b/src/z3c/form/browser/checkbox.py
@@ -40,14 +40,10 @@ class CheckBoxWidget(widget.HTMLInputWidget, SequenceWidget):
     def isChecked(self, term):
         return term.token in self.value
 
-    def update(self):
-        """See z3c.form.interfaces.IWidget."""
-        super(CheckBoxWidget, self).update()
-        widget.addFieldClass(self)
-        # XXX: this is to early for setup items. See select widget how this
-        # sould be done. Setup the items here doens't allow to override the
-        # widget.value in updateWidgets, ri
-        self.items = []
+    def items(self):
+        if self.terms is None:
+            return ()
+        items = []
         for count, term in enumerate(self.terms):
             checked = self.isChecked(term)
             id = '%s-%i' % (self.id, count)
@@ -56,15 +52,22 @@ class CheckBoxWidget(widget.HTMLInputWidget, SequenceWidget):
                                   default=term.title)
             else:
                 label = util.toUnicode(term.value)
-            self.items.append(
-                {'id':id, 'name':self.name + ':list', 'value':term.token,
-                 'label':label, 'checked':checked})
+            items.append(
+                {'id': id, 'name': self.name + ':list', 'value': term.token,
+                 'label': label, 'checked': checked})
+        return items
+
+    def update(self):
+        """See z3c.form.interfaces.IWidget."""
+        super(CheckBoxWidget, self).update()
+        widget.addFieldClass(self)
 
     def json_data(self):
         data = super(CheckBoxWidget, self).json_data()
-        data['options'] = self.items
+        data['options'] = list(self.items())
         data['type'] = 'check'
         return data
+
 
 @zope.component.adapter(zope.schema.interfaces.IField, interfaces.IFormLayer)
 @zope.interface.implementer(interfaces.IFieldWidget)

--- a/src/z3c/form/browser/checkbox.txt
+++ b/src/z3c/form/browser/checkbox.txt
@@ -206,7 +206,7 @@ the value (which is used as a backup label) contains non-ASCII characters:
   >>> terms = SimpleVocabulary.fromValues([b'yes\012', b'no\243'])
   >>> widget.terms = terms
   >>> widget.update()
-  >>> pprint(widget.items)
+  >>> pprint(list(widget.items()))
   [{'checked': False,
     'id': 'widget-id-0',
     'label': 'yes\n',

--- a/src/z3c/form/browser/radio.py
+++ b/src/z3c/form/browser/radio.py
@@ -36,7 +36,6 @@ class RadioWidget(widget.HTMLInputWidget, SequenceWidget):
 
     klass = u'radio-widget'
     css = u'radio'
-    items = ()
 
     def isChecked(self, term):
         return term.token in self.value
@@ -60,14 +59,9 @@ class RadioWidget(widget.HTMLInputWidget, SequenceWidget):
             IPageTemplate, name=self.mode + '_single')
         return template(self, item)
 
-    def update(self):
-        """See z3c.form.interfaces.IWidget."""
-        super(RadioWidget, self).update()
-        # XXX: this is to early for setup items. See select widget how this
-        # sould be done. Setup the items here doens't allow to override the
-        # widget.value in updateWidgets, ri
-        widget.addFieldClass(self)
-        self.items = []
+    def items(self):
+        if self.terms is None:
+            return
         for count, term in enumerate(self.terms):
             checked = self.isChecked(term)
             id = '%s-%i' % (self.id, count)
@@ -76,15 +70,20 @@ class RadioWidget(widget.HTMLInputWidget, SequenceWidget):
                                   default=term.title)
             else:
                 label = util.toUnicode(term.value)
-            self.items.append(
-                {'id':id, 'name':self.name, 'value':term.token,
-                 'label':label, 'checked':checked})
+            yield {'id': id, 'name': self.name, 'value': term.token,
+                   'label': label, 'checked': checked}
+
+    def update(self):
+        """See z3c.form.interfaces.IWidget."""
+        super(RadioWidget, self).update()
+        widget.addFieldClass(self)
 
     def json_data(self):
         data = super(RadioWidget, self).json_data()
-        data['options'] = self.items
+        data['options'] = list(self.items())
         data['type'] = 'radio'
         return data
+
 
 @zope.component.adapter(zope.schema.interfaces.IField, interfaces.IFormLayer)
 @zope.interface.implementer(interfaces.IFieldWidget)

--- a/src/z3c/form/browser/radio.txt
+++ b/src/z3c/form/browser/radio.txt
@@ -240,7 +240,7 @@ the value (which is used as a backup label) contains non-ASCII characters:
   >>> terms = SimpleVocabulary.fromValues([b'yes\012', b'no\243'])
   >>> widget.terms = terms
   >>> widget.update()
-  >>> pprint(widget.items)
+  >>> pprint(list(widget.items()))
   [{'checked': False,
     'id': 'widget-id-0',
     'label': 'yes\n',

--- a/src/z3c/form/term.py
+++ b/src/z3c/form/term.py
@@ -101,7 +101,8 @@ class SourceTerms(Terms):
     zope.schema.interfaces.IChoice,
     interfaces.IWidget)
 def ChoiceTerms(context, request, form, field, widget):
-    field = field.bind(context)
+    if field.context is None:
+        field = field.bind(context)
     terms = field.vocabulary
     return zope.component.queryMultiAdapter(
         (context, request, form, field, terms, widget),


### PR DESCRIPTION
- RadioWidget items are better determined when they are needed [agroszer]

- CheckBoxWidget items are better determined when they are needed [agroszer]

- Bugfix: The ``ChoiceTerms`` adapter blindly assumed that the passed in field
  is unbound, which is not necessarily the case in interesting ObjectWidget
  scenarios. Not it checks for a non-None field context first. [srichter]