### PR TITLE
Fix `orderedselect_input.js` resource

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,8 +5,8 @@ CHANGES
 3.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix `orderedselect_input.js` resource to be usable on browser layers which do
+  not extend ``zope.publisher.interfaces.browser.IDefaultBrowserLayer``.
 
 3.3.0 (2016-03-09)
 ------------------

--- a/src/z3c/form/browser/orderedselect.zcml
+++ b/src/z3c/form/browser/orderedselect.zcml
@@ -44,6 +44,7 @@
       />
 
   <browser:resource
+      layer="z3c.form.interfaces.IFormLayer"
       name="orderedselect_input.js"
       file="orderedselect_input.js"
       />


### PR DESCRIPTION
Make it usable on browser layers which do not extend ``zope.publisher.interfaces.browser.IDefaultBrowserLayer``.