### PR TITLE
Fix handling of missing values in collections

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ CHANGES
 3.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix handling of missing terms in collections. (See version 2.9 describing
+  this feature.)
 
 
 3.3.0 (2016-03-09)

--- a/src/z3c/form/term.py
+++ b/src/z3c/form/term.py
@@ -80,7 +80,10 @@ class SourceTerms(Terms):
         raise LookupError(token)
 
     def getValue(self, token):
-        return self.terms.getValue(token)
+        try:
+            return self.terms.getValue(token)
+        except KeyError:
+            raise LookupError(token)
 
     def __iter__(self):
         for value in self.source:
@@ -294,7 +297,21 @@ class MissingCollectionTermsMixin(MissingTermsBase):
                         # fall back on LookupError, otherwise we might accept
                         # any crap coming from the request
                         return term
-            raise LookupError(token)
+            raise
+
+    def getValue(self, token):
+        try:
+            return super(MissingCollectionTermsMixin, self).getValue(token)
+        except LookupError:
+            if self._canQueryCurrentValue():
+                for value in self._queryCurrentValue():
+                    term = self._makeMissingTerm(value)
+                    if term.token == token:
+                        # check if the given token matches the value, if not
+                        # fall back on LookupError, otherwise we might accept
+                        # any crap coming from the request
+                        return value
+            raise
 
 
 class MissingCollectionTermsVocabulary(MissingCollectionTermsMixin,

--- a/src/z3c/form/term.txt
+++ b/src/z3c/form/term.txt
@@ -360,7 +360,7 @@ stored objects still has this value.
 
 The same goes with looking up a term by value:
 
-  >>> terms.getTerm('42')
+  >>> terms.getTerm(42)
   Traceback (most recent call last):
   ...
   LookupError: 42

--- a/src/z3c/form/term.txt
+++ b/src/z3c/form/term.txt
@@ -529,3 +529,92 @@ Finally, there are terms adapters for all collections:
   ...     rating_context, request, None, contextualSourceRatingsField, widget)
   >>> [entry.title for entry in terms]
   [u'ugly', u'nice', u'great']
+
+
+Missing terms in collections
+############################
+
+Sometimes it happens that a value goes away from the source, but our
+stored collection still has this value.
+
+  >>> zope.component.provideAdapter(term.MissingCollectionTermsSource)
+
+  >>> terms = term.CollectionTerms(
+  ...     RatingContext(), request, None, contextualSourceRatingsField, widget)
+  >>> terms
+  <z3c.form.term.MissingCollectionTermsSource object at 0x...>
+  >>> terms.getTermByToken('42')
+  Traceback (most recent call last):
+  ...
+  LookupError: 42
+
+The same goes with looking up a term by value:
+
+  >>> terms.getTerm(42)
+  Traceback (most recent call last):
+  ...
+  LookupError: 42
+
+Ooops, well this works only if the context has the right value for us.
+This is because we don't want to accept any crap that's coming from HTML.
+
+  >>> class IRatings(zope.interface.Interface):
+  ...     ratings = zope.schema.List(
+  ...         title=u'Contextual Sourced Ratings',
+  ...         value_type=contextualSourceRatingField)
+  >>> @zope.interface.implementer(IRatings)
+  ... class Ratings(object):
+  ...     ratings = None
+  ...     base_value = 10
+
+  >>> ctx = Ratings()
+  >>> ctx.ratings = [42, 10]
+
+  >>> ratingsWidget = z3c.form.widget.Widget(request)
+  >>> ratingsWidget.context = ctx
+  >>> from z3c.form import interfaces
+  >>> zope.interface.alsoProvides(ratingsWidget, interfaces.IContextAware)
+  >>> from z3c.form.datamanager import AttributeField
+  >>> zope.component.provideAdapter(AttributeField)
+
+  >>> terms = term.CollectionTerms(
+  ...     ctx, request, None, IRatings['ratings'], ratingsWidget)
+
+Here we go:
+
+  >>> term = terms.getTerm(42)
+  >>> missingTerm = terms.getTermByToken('42')
+
+We get the term, we passed the token, the value is coming from the context.
+
+  >>> missingTerm.token
+  '42'
+  >>> missingTerm.value
+  42
+
+We cannot figure the title, so we construct one.
+Override ``makeMissingTerm`` if you want your own.
+
+  >>> missingTerm.title
+  u'Missing: ${value}'
+
+Still we raise LookupError if the token does not fit the context's value:
+
+  >>> missingTerm = terms.getTermByToken('99')
+  Traceback (most recent call last):
+  ...
+  LookupError: 99
+
+The same goes with looking up a term by value.
+We get the term if the context's value fits:
+
+  >>> missingTerm = terms.getTerm(42)
+  >>> missingTerm.token
+  '42'
+
+And an exception if it does not:
+
+  >>> missingTerm = terms.getTerm(99)
+  Traceback (most recent call last):
+  ...
+  LookupError: 99

--- a/src/z3c/form/term.txt
+++ b/src/z3c/form/term.txt
@@ -555,6 +555,14 @@ The same goes with looking up a term by value:
   ...
   LookupError: 42
 
+The same goes with looking up a value by the token:
+
+  >>> terms.getValue('42')
+  Traceback (most recent call last):
+  ...
+  LookupError: 42
+
+
 Ooops, well this works only if the context has the right value for us.
 This is because we don't want to accept any crap that's coming from HTML.
 
@@ -597,6 +605,11 @@ Override ``makeMissingTerm`` if you want your own.
 
   >>> missingTerm.title
   u'Missing: ${value}'
+
+We can get the value for a missing term:
+
+  >>> terms.getValue('42')
+  42
 
 Still we raise LookupError if the token does not fit the context's value:
 


### PR DESCRIPTION
The code introduced in version 2.9 to handle missing values in vocabularies and the adaption to sources in 3.0.3 did not work for collections because it was not able to to handle values which are collections of values.

Adapted the code and added a test for the collections.