### PR TITLE
Remove z3c.coverage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ setup(
         test=[
             'lxml >= 2.1.1',
             'persistent',
-            'z3c.coverage',
             'z3c.template >= 1.3',
             'zc.sourcefactory',
             'zope.container',


### PR DESCRIPTION
Is there any reason to install that when running tests? That can be a separate step right?

At Plone  we wanted to upgrade coverage to version 4.x but z3c.coverage does not allow that and z3c.form is the only dependency that relies on it.