### PR TITLE
Turned `items` into a property again on all widgets. [master]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,13 @@ CHANGES
 3.3.1 (unreleased)
 ------------------
 
+- Turned ``items`` into a property again on all widgets.
+  For the select widget it was a method since 2.9.0.
+  For the radio and checkbox widgets it was a method since 3.2.10.
+  For orderedselect and multi it was always a property.
+  Fixes https://github.com/zopefoundation/z3c.form/issues/44
+  [maurits]
+
 - Fix handling of missing terms in collections. (See version 2.9 describing
   this feature.)
 
@@ -24,6 +31,8 @@ CHANGES
     it was causing more problems than good
 
   * added high level integration tests
+
+- Removed ``z3c.coverage`` from ``test`` extra.  [gforcada, maurits]
 
 
 3.2.10 (2016-03-09)

--- a/src/z3c/form/browser/checkbox.py
+++ b/src/z3c/form/browser/checkbox.py
@@ -40,6 +40,7 @@ class CheckBoxWidget(widget.HTMLInputWidget, SequenceWidget):
     def isChecked(self, term):
         return term.token in self.value
 
+    @property
     def items(self):
         if self.terms is None:
             return ()
@@ -64,7 +65,7 @@ class CheckBoxWidget(widget.HTMLInputWidget, SequenceWidget):
 
     def json_data(self):
         data = super(CheckBoxWidget, self).json_data()
-        data['options'] = list(self.items())
+        data['options'] = list(self.items)
         data['type'] = 'check'
         return data
 

--- a/src/z3c/form/browser/checkbox.txt
+++ b/src/z3c/form/browser/checkbox.txt
@@ -206,7 +206,7 @@ the value (which is used as a backup label) contains non-ASCII characters:
   >>> terms = SimpleVocabulary.fromValues([b'yes\012', b'no\243'])
   >>> widget.terms = terms
   >>> widget.update()
-  >>> pprint(list(widget.items()))
+  >>> pprint(list(widget.items))
   [{'checked': False,
     'id': 'widget-id-0',
     'label': 'yes\n',

--- a/src/z3c/form/browser/radio.py
+++ b/src/z3c/form/browser/radio.py
@@ -59,6 +59,7 @@ class RadioWidget(widget.HTMLInputWidget, SequenceWidget):
             IPageTemplate, name=self.mode + '_single')
         return template(self, item)
 
+    @property
     def items(self):
         if self.terms is None:
             return
@@ -81,7 +82,7 @@ class RadioWidget(widget.HTMLInputWidget, SequenceWidget):
 
     def json_data(self):
         data = super(RadioWidget, self).json_data()
-        data['options'] = list(self.items())
+        data['options'] = list(self.items)
         data['type'] = 'radio'
         return data
 

--- a/src/z3c/form/browser/radio.txt
+++ b/src/z3c/form/browser/radio.txt
@@ -240,7 +240,7 @@ the value (which is used as a backup label) contains non-ASCII characters:
   >>> terms = SimpleVocabulary.fromValues([b'yes\012', b'no\243'])
   >>> widget.terms = terms
   >>> widget.update()
-  >>> pprint(list(widget.items()))
+  >>> pprint(list(widget.items))
   [{'checked': False,
     'id': 'widget-id-0',
     'label': 'yes\n',

--- a/src/z3c/form/browser/select.py
+++ b/src/z3c/form/browser/select.py
@@ -51,6 +51,7 @@ class SelectWidget(widget.HTMLSelectWidget, SequenceWidget):
         super(SelectWidget, self).update()
         widget.addFieldClass(self)
 
+    @property
     def items(self):
         if self.terms is None:  # update() has not been called yet
             return ()
@@ -98,7 +99,7 @@ class SelectWidget(widget.HTMLSelectWidget, SequenceWidget):
 
     def json_data(self):
         data = super(SelectWidget, self).json_data()
-        data['options'] = self.items()
+        data['options'] = self.items
         data['type'] = 'select'
         return data
 


### PR DESCRIPTION
For the select widget it was a method since 2.9.0.
For the radio and checkbox widgets it was a method since 3.2.10.
For orderedselect and multi it was always a property.

Fixes https://github.com/zopefoundation/z3c.form/issues/44