### PR TITLE
Fix TypeError: object of type 'generator' has no ``len()``. [3.2]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ CHANGES
 3.2.11 (unreleased)
 -------------------
 
+- Fix TypeError: object of type 'generator' has no ``len()``.
+  Happens with z3c.formwidget.query.  [maurits]
+
 - Turned ``items`` into a property again on all widgets.
   For the select widget it was a method since 2.9.0.
   For the radio and checkbox widgets it was a method since 3.2.10.

--- a/src/z3c/form/browser/checkbox_input.pt
+++ b/src/z3c/form/browser/checkbox_input.pt
@@ -2,6 +2,7 @@
      xmlns:tal="http://xml.zope.org/namespaces/tal"
      tal:omit-tag=""
      tal:define="items view/items;
+                 items python:list(items);
                  single_checkbox python:len(items) == 1">
 <span tal:attributes="id view/id"
       tal:omit-tag="single_checkbox"


### PR DESCRIPTION
Happens with z3c.formwidget.query.

See test failure when using z3c.form branch 3.2.x on Plone 4.3:
http://jenkins.plone.org/job/pull-request-4.3/424/testReport/junit/plone.formwidget/autocomplete/README_txt/