### PR TITLE
Avoid duplicate IDs when using `QuerySourceRadioWidget` for non-required fields.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,9 @@ CHANGES
 3.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid duplicated IDs when using a non-required field with
+  ``z3c.formwidget.query.widget.QuerySourceRadioWidget``.
+  [pgrunewald]
 
 
 3.4.0 (2016-11-15)

--- a/src/z3c/form/browser/radio.py
+++ b/src/z3c/form/browser/radio.py
@@ -44,7 +44,6 @@ class RadioWidget(widget.HTMLInputWidget, SequenceWidget):
         terms = list(self.terms)
         try:
             term = self.terms.getTermByToken(value)
-            id = '%s-%i' % (self.id, terms.index(term))
         except LookupError:
             if value == SequenceWidget.noValueToken:
                 term = SimpleTerm(value)
@@ -52,6 +51,8 @@ class RadioWidget(widget.HTMLInputWidget, SequenceWidget):
                 id = '%s-novalue' % self.id
             else:
                 raise
+        else:
+            id = '%s-%i' % (self.id, terms.index(term))
         checked = self.isChecked(term)
         item = {'id': id, 'name': self.name, 'value': term.token,
                 'checked': checked}

--- a/src/z3c/form/browser/radio.py
+++ b/src/z3c/form/browser/radio.py
@@ -44,14 +44,15 @@ class RadioWidget(widget.HTMLInputWidget, SequenceWidget):
         terms = list(self.terms)
         try:
             term = self.terms.getTermByToken(value)
+            id = '%s-%i' % (self.id, terms.index(term))
         except LookupError:
             if value == SequenceWidget.noValueToken:
                 term = SimpleTerm(value)
                 terms.insert(0, term)
+                id = '%s-novalue' % self.id
             else:
                 raise
         checked = self.isChecked(term)
-        id = '%s-%i' % (self.id, terms.index(term))
         item = {'id': id, 'name': self.name, 'value': term.token,
                 'checked': checked}
         template = zope.component.getMultiAdapter(

--- a/src/z3c/form/browser/radio.txt
+++ b/src/z3c/form/browser/radio.txt
@@ -57,7 +57,7 @@ If we render the widget we only get the empty marker:
   <input name="widget.name-empty-marker" type="hidden" value="1" />
 
 Let's provide some values for this widget. We can do this by defining a source
-providing ITerms. This source uses descriminators wich will fit for our setup.
+providing ITerms. This source uses discriminators which will fit for our setup.
 
   >>> import zope.schema.interfaces
   >>> import z3c.form.term
@@ -166,6 +166,15 @@ We can also render the input elements for each value separately:
    >>> print(widget.renderForValue('false'))
    <input id="widget-id-1" name="widget.name" class="radio-widget"
           value="false" type="radio" />
+
+Additionally we can render the "no value" input element used for non-required fields:
+
+  >>> from z3c.form.widget import SequenceWidget
+  >>> print(SequenceWidget.noValueToken)
+  --NOVALUE--
+  >>> print(widget.renderForValue(SequenceWidget.noValueToken))
+  <input id="widget-id-novalue" name="widget.name" class="radio-widget"
+          value="--NOVALUE--" type="radio" />
 
 Check HIDDEN_MODE:
 


### PR DESCRIPTION
This problem seems to be related with this [commit](https://github.com/zopefoundation/z3c.form/commit/d36f01ba059d46fc19eb3680d381335fca2234bd). I found out in my setup, that it was possible to generate two input elements with duplicate IDs (ending with "-0"), when using a non-required field with QuerySourceRadioWidget. Since QuerySourceRadioWidget uses "-novalue" for the --NOVALUE-- item, I would suggest to use it here as well (also see [source](https://github.com/zopefoundation/z3c.formwidget.query/blob/802bec6880a7d36db0e670522135a7ad311ac8ee/src/z3c/formwidget/query/widget.py#L120)). Otherwise `<label for=".."/>` and the input element's ID would not match.