### PR TITLE
Drop using z3c.recipe.sphinxdoc.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,6 @@
 [buildout]
 develop = . benchmark
 parts = test coverage-test coverage-report python
-; # Parts that do not build due to the setuptools mess:
-;        docs
 ; # Parts with recipes not ported to Python 3:
 ;        test-with-z3cpt
 ;        checker i18n
@@ -13,7 +11,6 @@ versions = versions
 lxml = 3.1.0
 python-gettext = 2.1
 sourcecodegen = 0.6.14
-z3c.recipe.sphinxdoc = 1.0.0
 z3c.template = 2.0.0a1
 zc.sourcefactory = 1.0.0a1
 
@@ -61,13 +58,6 @@ arguments = ('${buildout:directory}/coverage', '${buildout:directory}/coverage/r
 [pocompile]
 recipe = zc.recipe.egg
 eggs = zest.pocompile
-
-[docs]
-recipe = z3c.recipe.sphinxdoc
-eggs = z3c.form [docs]
-build-dir = ${buildout:directory}/docs
-default.css =
-layout.html =
 
 [i18n]
 recipe = lovely.recipe:i18n


### PR DESCRIPTION
After the documentation is now on RTD via the standard way there is no need for z3c.recipe.sphinxdoc any more here.