### PR TITLE
Upgrade the major version 4 to reflect the breaking changes in 3.3.0.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,13 @@
 Changelog
 =========
 
-3.6 (unreleased)
+4.0 (unreleased)
 ----------------
+
+- Upgrade the major version 4 to reflect the breaking changes in 3.3.0.
+  (Version 3.6 will be a re-release of 3.2.x not containing the changes since
+  3.3.0 besides cherry-picks.)
+  Fixes: https://github.com/zopefoundation/z3c.form/issues/41
 
 - Host documentation at https://z3cform.readthedocs.io
 

--- a/README.rst
+++ b/README.rst
@@ -26,5 +26,13 @@ according widgets. Its goal
 is to provide a simple API but with the ability to easily customize any data or
 steps.
 
+There are currently two maintained branches:
+
+* `master <https://github.com/zopefoundation/z3c.form/tree/master>` with the
+  latest changes
+* `3.x <https://github.com/zopefoundation/z3c.form/tree/3.x>` without the
+  object widget overhaul and still including the ``ObjectSubForm`` and
+  the ``SubformAdapter``.
+
 Documentation on this implementation and its API can be found at
 https://z3cform.readthedocs.io/

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def alltests():
 
 setup(
     name='z3c.form',
-    version='3.6.dev0',
+    version='4.0.dev0',
     author="Stephan Richter, Roger Ineichen and the Zope Community",
     author_email="zope-dev@zope.org",
     description="An advanced form and widget framework for Zope 3",


### PR DESCRIPTION
Version 3.6 will be a re-release of 3.2.x not containing the changes since 3.3.0 besides cherry-picks.

Fixes #41.