### PR TITLE
try to fix #89

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changelog
 
 - Add support for Python 3.8b4.
 
+- Try to fix the buggy hidden mode behaviour of checkbox widgets
+  (`#89 <https://github.com/zopefoundation/z3c.form/issues/89`_).
+
 
 4.1.2 (2019-03-04)
 ------------------

--- a/src/z3c/form/browser/checkbox.rst
+++ b/src/z3c/form/browser/checkbox.rst
@@ -172,10 +172,8 @@ Check HIDDEN_MODE:
   <span class="option">
     <input type="hidden" id="widget-id-0" name="widget.name:list"
            class="checkbox-widget" value="true" />
-  </span><span class="option">
-    <input type="hidden" id="widget-id-1" name="widget.name:list"
-           class="checkbox-widget" value="false" />
   </span>
+  <input name="widget.name-empty-marker" type="hidden" value="1" />
 
 The checkbox json_data representation:
   >>> from pprint import pprint
@@ -334,7 +332,7 @@ Check HIDDEN_MODE:
   ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
   ...     IPageTemplate, name='hidden')
 
-  >>> widget.value = 'true'
+  >>> widget.value = 'selected'
   >>> widget.mode = interfaces.HIDDEN_MODE
   >>> print(widget.render())
   <span class="option">
@@ -342,6 +340,7 @@ Check HIDDEN_MODE:
            name="widget.name:list"
            class="single-checkbox-widget" value="selected" />
   </span>
+  <input name="widget.name-empty-marker" type="hidden" value="1" />
 
 
 Term with non ascii __str__

--- a/src/z3c/form/browser/checkbox_hidden.pt
+++ b/src/z3c/form/browser/checkbox_hidden.pt
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
      xmlns:tal="http://xml.zope.org/namespaces/tal"
      tal:omit-tag="">
-<span class="option"
-      tal:repeat="item view/items">
+<tal:repeat repeat="item view/items">
+<span class="option" tal:condition="item/checked">
   <input id="" name="" value="" class="hidden-widget" title=""
          tabindex="" accesskey=""
          type="hidden"
@@ -33,4 +33,7 @@
                          accesskey view/accesskey;
                          onselect view/onselect" />
 </span>
+</tal:repeat>
+<input name="field-empty-marker" type="hidden" value="1"
+       tal:attributes="name string:${view/name}-empty-marker" />
 </html>


### PR DESCRIPTION
This PR tries to fix #89.
It changes the template `checkbox_hidden.pt` to produce the expected markup (compatible to the one produced by `checkbox_input.pt`) and adapts the tests in `checkbox.rst` accordingly.

**But** I have no confidence in the tests and in the implementation of `checkbox.SingleCheckboxWidget`.

The basic `CheckboxWidget` is designed as a multiple option widget. As such, it is controlled by a sequence of terms (the possible options) and its value is naturally a sequence of the selected options. Accordingly, its `isChecked` method is defined as:
```
    def isChecked(self, term):
        return term.token in self.value
```
However, the tests (in `checkbox.rst`) always assign strings to `widget.value` (instead of a sequence of strings). This works accidentally, because `in` can accept both a sequence as well as a string as right argument. But, applied to strings, it can wrongly return `True`.

We can expect (from the name) that  `SingleCheckboxWidget` is designed for a single value. Thus, its value may be a string. However,  it should then get its own `IsChecked` method definition reflecting this type.

`SingleCheckboxWidget` can be expected to be used as a widget for boolean fields. By default, it has a single term `selected`. I am not convinced that this is the most natural representation of `True` and therefore, I am not sure that a field value `True` is really mapped to the widget value `'selected'`(which is necessary to make it work correctly).