### PR TITLE
Fixed possible UnicodeDecodeError in setup.py on Python 3.6. [3.x]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,11 @@ CHANGES
 3.7.1 (unreleased)
 ------------------
 
+- Fixed possible UnicodeDecodeError in setup.py on Python 3.6.
+  Put the long description in setup.cfg, without replacing characters.
+
 - Drop Python 3.4 support.  Add 3.7 and 3.8 support.
+
 - Fixed compatibility with changed repeat syntax.
   Fixes `issue 94 <https://github.com/zopefoundation/z3c.form/issues/94>`_.
 

--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,6 @@
 This package provides an implementation for HTML and JSON forms and widgets. The goal
 is to provide a simple API but with the ability to easily customize any data or
 steps.
+
+
+.. contents::

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,23 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+long_description = file:
+  README.txt,
+  src/z3c/form/README.txt,
+  src/z3c/form/form.txt,
+  src/z3c/form/group.txt,
+  src/z3c/form/subform.txt,
+  src/z3c/form/field.txt,
+  src/z3c/form/button.txt,
+  src/z3c/form/zcml.txt,
+  src/z3c/form/validator.txt,
+  src/z3c/form/widget.txt,
+  src/z3c/form/contentprovider.txt,
+  src/z3c/form/action.txt,
+  src/z3c/form/value.txt,
+  src/z3c/form/datamanager.txt,
+  src/z3c/form/converter.txt,
+  src/z3c/form/term.txt,
+  src/z3c/form/util.txt,
+  CHANGES.txt

--- a/setup.py
+++ b/setup.py
@@ -13,16 +13,7 @@
 ##############################################################################
 """Setup
 """
-import os
 from setuptools import setup, find_packages
-
-
-def read(*rnames):
-    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
-        text = f.read()
-    if isinstance(text, bytes):
-        text = text.decode('utf-8')
-    return text.encode('ascii', 'xmlcharrefreplace').decode()
 
 
 def alltests():
@@ -41,39 +32,12 @@ def alltests():
     return unittest.TestSuite(suites)
 
 
-chapters = '\n'.join(
-    [read('src', 'z3c', 'form', name)
-    for name in ('README.txt',
-                 'form.txt',
-                 'group.txt',
-                 'subform.txt',
-                 'field.txt',
-                 'button.txt',
-                 'zcml.txt',
-                 'validator.txt',
-                 'widget.txt',
-                 'contentprovider.txt',
-                 'action.txt',
-                 'value.txt',
-                 'datamanager.txt',
-                 'converter.txt',
-                 'term.txt',
-                 'util.txt',
-                 )])
-
-
 setup(
     name='z3c.form',
     version='3.7.1.dev0',
     author="Stephan Richter, Roger Ineichen and the Zope Community",
     author_email="zope-dev@zope.org",
     description="An advanced form and widget framework for Zope 3",
-    long_description=(
-        read('README.txt')
-        + '\n\n' +
-        '.. contents:: \n\n' + chapters
-        + '\n\n'
-        + read('CHANGES.txt')),
     license="ZPL 2.1",
     keywords="zope3 form widget",
     classifiers=[


### PR DESCRIPTION
Put the long description in setup.cfg, without replacing characters.
See this error on Plone Jenkins, https://jenkins.plone.org/job/plone-5.2-python-3.6/1058/console

```
Develop: '/home/jenkins/workspace/plone-5.2-python-3.6/src/z3c.form'
Traceback (most recent call last):
  File "/tmp/tmps_fh_how", line 14, in <module>
    exec(compile(f.read(), '/home/jenkins/workspace/plone-5.2-python-3.6/src/z3c.form/setup.py', 'exec'))
  File "/home/jenkins/workspace/plone-5.2-python-3.6/src/z3c.form/setup.py", line 61, in <module>
    'util.txt',
  File "/home/jenkins/workspace/plone-5.2-python-3.6/src/z3c.form/setup.py", line 46, in <listcomp>
    for name in ('README.txt',
  File "/home/jenkins/workspace/plone-5.2-python-3.6/src/z3c.form/setup.py", line 22, in read
    text = f.read()
  File "/home/jenkins/shiningpanda/jobs/65a48de5/virtualenvs/d41d8cd9/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 752: ordinal not in range(128)
While:
  Installing.
  Processing develop directory '/home/jenkins/workspace/plone-5.2-python-3.6/src/z3c.form'.
```

I have seen it go wrong for more packages the last couple of months.
Locally I see no problem with Python 3.6, so it *could* be a problem only on one Jenkins node.
But if it happens there, it might happen for other users too.

See another package where I initially fixed it by hacking something in `setup.py`,
and then replaced it with `setup.cfg` in this commit:
https://github.com/plone/Products.CMFPlacefulWorkflow/commit/eda6670f50436d2dea426a389563df1223760978

Difference in output is very little, but seems an improvement:

```
$ diff orig new
9948c9948
<   >>> id = util.createId(u'&#196;ndern')
---
>   >>> id = util.createId(u'Ändern')
9967c9967
<   >>> id = util.createCSSId(u'&#1593;&#1614;&#1585;&#1614;')
---
>   >>> id = util.createCSSId(u'عَرَ')
```

Or with screen shots.

--------
**Old:**

![Screenshot 2020-09-04 at 09 47 26](https://user-images.githubusercontent.com/210587/92214882-5eb96400-ee94-11ea-9ff4-23bbc6efe1a8.png)
--------

**New:**

![Screenshot 2020-09-04 at 09 48 56](https://user-images.githubusercontent.com/210587/92214968-6973f900-ee94-11ea-9602-a9435b51fbb1.png)
--------

The new text is the same as the text that is actually in the file that we include:
https://github.com/zopefoundation/z3c.form/blob/3.7.0/src/z3c/form/util.txt#L29-L57
