### PR TITLE
HTMLFormElement.attributes: Allow to extend HTML attributes programmatically.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 5.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- HTMLFormElement.attributes: Allow to extend HTML attributes programmatically.
 
 
 5.0 (2023-07-17)

--- a/src/z3c/form/browser/widget.py
+++ b/src/z3c/form/browser/widget.py
@@ -163,6 +163,58 @@ class HTMLFormElement(WidgetLayoutSupport):
         if self.mode == INPUT_MODE and self.required:
             self.addClass('required')
 
+    @property
+    def _html_attributes(self):
+        """Return a list of HTML attributes managed by this class."""
+        # This is basically a list of all the FieldProperty names except for
+        # the `css` property, which is not an HTML attribute.
+        return [
+            "id",
+            "klass",  # will be changed to `class`
+            "style",
+            "title",
+            "lang",
+            "onclick",
+            "ondblclick",
+            "onmousedown",
+            "onmouseup",
+            "onmouseover",
+            "onmousemove",
+            "onmouseout",
+            "onkeypress",
+            "onkeydown",
+            "onkeyup",
+            "disabled",
+            "tabindex",
+            "onfocus",
+            "onblur",
+            "onchange",
+        ]
+
+    _attributes = None
+
+    @property
+    def attributes(self) -> dict:
+        # If `attributes` were explicitly set, return them.
+        if isinstance(self._attributes, dict):
+            return self._attributes
+
+        # Otherwise return the default set of non-empty HTML attributes.
+        attributes_items = map(
+            lambda attr: (
+                attr if attr != "klass" else "class",
+                getattr(self, attr, None),
+            ),
+            self._html_attributes,
+        )
+        self._attributes = {key: val for key, val in attributes_items if val}
+        return self._attributes
+
+    @attributes.setter
+    def attributes(self, value: dict):
+        # Store the explicitly set attributes.
+        self._attributes = value
+
 
 @zope.interface.implementer(interfaces.IHTMLInputWidget)
 class HTMLInputWidget(HTMLFormElement):
@@ -171,6 +223,19 @@ class HTMLInputWidget(HTMLFormElement):
     alt = FieldProperty(interfaces.IHTMLInputWidget['alt'])
     accesskey = FieldProperty(interfaces.IHTMLInputWidget['accesskey'])
     onselect = FieldProperty(interfaces.IHTMLInputWidget['onselect'])
+
+    @property
+    def _html_attributes(self):
+        attributes = super()._html_attributes
+        attributes.extend(
+            [
+                "readonly",
+                "alt",
+                "accesskey",
+                "onselect",
+            ]
+        )
+        return attributes
 
 
 @zope.interface.implementer(interfaces.IHTMLTextInputWidget)
@@ -182,6 +247,19 @@ class HTMLTextInputWidget(HTMLInputWidget):
     autocapitalize = FieldProperty(
         interfaces.IHTMLTextInputWidget['autocapitalize'])
 
+    @property
+    def _html_attributes(self):
+        attributes = super()._html_attributes
+        attributes.extend(
+            [
+                "size",
+                "maxlength",
+                "placeholder",
+                "autocapitalize",
+            ]
+        )
+        return attributes
+
 
 @zope.interface.implementer(interfaces.IHTMLTextAreaWidget)
 class HTMLTextAreaWidget(HTMLFormElement):
@@ -192,12 +270,37 @@ class HTMLTextAreaWidget(HTMLFormElement):
     accesskey = FieldProperty(interfaces.IHTMLTextAreaWidget['accesskey'])
     onselect = FieldProperty(interfaces.IHTMLTextAreaWidget['onselect'])
 
+    @property
+    def _html_attributes(self):
+        attributes = super()._html_attributes
+        attributes.extend(
+            [
+                "rows",
+                "cols",
+                "readonly",
+                "accesskey",
+                "onselect",
+            ]
+        )
+        return attributes
+
 
 @zope.interface.implementer(interfaces.IHTMLSelectWidget)
 class HTMLSelectWidget(HTMLFormElement):
 
     multiple = FieldProperty(interfaces.IHTMLSelectWidget['multiple'])
     size = FieldProperty(interfaces.IHTMLSelectWidget['size'])
+
+    @property
+    def _html_attributes(self):
+        attributes = super()._html_attributes
+        attributes.extend(
+            [
+                "multiple",
+                "size",
+            ]
+        )
+        return attributes
 
 
 def addFieldClass(widget):

--- a/src/z3c/form/browser/widget.py
+++ b/src/z3c/form/browser/widget.py
@@ -164,7 +164,7 @@ class HTMLFormElement(WidgetLayoutSupport):
             self.addClass('required')
 
     @property
-    def _html_attributes(self):
+    def _html_attributes(self) -> list:
         """Return a list of HTML attributes managed by this class."""
         # This is basically a list of all the FieldProperty names except for
         # the `css` property, which is not an HTML attribute.
@@ -200,13 +200,10 @@ class HTMLFormElement(WidgetLayoutSupport):
             return self._attributes
 
         # Otherwise return the default set of non-empty HTML attributes.
-        attributes_items = map(
-            lambda attr: (
-                attr if attr != "klass" else "class",
-                getattr(self, attr, None),
-            ),
-            self._html_attributes,
-        )
+        attributes_items = [
+            ("class" if attr == "klass" else attr, getattr(self, attr, None))
+            for attr in self._html_attributes
+        ]
         self._attributes = {key: val for key, val in attributes_items if val}
         return self._attributes
 
@@ -225,7 +222,7 @@ class HTMLInputWidget(HTMLFormElement):
     onselect = FieldProperty(interfaces.IHTMLInputWidget['onselect'])
 
     @property
-    def _html_attributes(self):
+    def _html_attributes(self) -> list:
         attributes = super()._html_attributes
         attributes.extend(
             [
@@ -248,7 +245,7 @@ class HTMLTextInputWidget(HTMLInputWidget):
         interfaces.IHTMLTextInputWidget['autocapitalize'])
 
     @property
-    def _html_attributes(self):
+    def _html_attributes(self) -> list:
         attributes = super()._html_attributes
         attributes.extend(
             [
@@ -271,7 +268,7 @@ class HTMLTextAreaWidget(HTMLFormElement):
     onselect = FieldProperty(interfaces.IHTMLTextAreaWidget['onselect'])
 
     @property
-    def _html_attributes(self):
+    def _html_attributes(self) -> list:
         attributes = super()._html_attributes
         attributes.extend(
             [
@@ -292,7 +289,7 @@ class HTMLSelectWidget(HTMLFormElement):
     size = FieldProperty(interfaces.IHTMLSelectWidget['size'])
 
     @property
-    def _html_attributes(self):
+    def _html_attributes(self) -> list:
         attributes = super()._html_attributes
         attributes.extend(
             [

--- a/src/z3c/form/browser/widget.rst
+++ b/src/z3c/form/browser/widget.rst
@@ -50,3 +50,91 @@ The duplicate removal also keeps the original order of CSS classes::
   >>> form.klass
   'my-css-class another-class third-class'
 
+
+attributes
+..........
+
+On widgets you can programatically add, remove or modify HTML attributes::
+
+  >>> form = HTMLFormElement()
+  >>> form.id = "my-input"
+  >>> form.title = "This is my input."
+
+  >>> form.attributes
+  {'id': 'my-input', 'title': 'This is my input.'}
+
+
+Only attributes with values are included in :code:`attributes`::
+
+  >>> form = HTMLFormElement()
+  >>> form.id = "my-input"
+
+  >>> form.attributes
+  {'id': 'my-input'}
+
+
+The :code:`klass` attibute of the :code:`HTMLFormElement` is changed to :code:`class`::
+
+  >>> form = HTMLFormElement()
+  >>> form.klass = "class-a class-b"
+
+  >>> form.attributes
+  {'class': 'class-a class-b'}
+
+
+Once :code:`attributes` was accessed you cannot set the HTML attributes on the `HTMLFormElement` directly anymore::
+
+  >>> form = HTMLFormElement()
+  >>> form.id = "my-input"
+
+  >>> form.attributes
+  {'id': 'my-input'}
+
+  >>> form.id = "no-input"
+  >>> form.title = "This is my input."
+
+  >>> form.attributes
+  {'id': 'my-input'}
+
+
+But you can change them via the :code:`attributes` property::
+
+  >>> form = HTMLFormElement()
+  >>> form.id = "my-input"
+
+  >>> form.attributes
+  {'id': 'my-input'}
+
+  >>> form.attributes["id"] = "no-input"
+  >>> form.attributes["title"] = "Okay. No input then."
+
+  >>> form.attributes
+  {'id': 'no-input', 'title': 'Okay. No input then.'}
+
+  >>> form.attributes.update({"title": "The no input input.", "class": "class-a"})
+
+  >>> form.attributes
+  {'id': 'no-input', 'title': 'The no input input.', 'class': 'class-a'}
+
+You can delete items::
+
+  >>> del form.attributes["class"]
+  >>> form.attributes
+  {'id': 'no-input', 'title': 'The no input input.'}
+
+
+And directly set it anew::
+
+  >>> form.attributes = {'id': 'okay', 'title': 'I give up.'}
+  >>> form.attributes
+  {'id': 'okay', 'title': 'I give up.'}
+
+
+You can use attributes to render inputs in a generic way without explicitly including all the HTML attributes.
+
+Note: This only works if you use Chameleon templates. It does not work with the Zope PageTemplate reference implementation.
+
+This is how you would write your Chameleon template::
+
+  <input type="text" tal:attributes="view/attributes" />
+


### PR DESCRIPTION
Came out of necessity and the discussion at: https://github.com/plone/plone.app.z3cform/pull/176

See the z3c.form.browser.widgets.rst doctest on how to use it.
Basically it allows for attribute expansion in Chameleon templates like:

```
<input type="text" tal:attributes="view/attributes" />
```

You can just set individual attributes like so:
```
if widget.id == "cancel":
    widget.attributes["formnovalidate"] = "formnovalidate"
```

There is no need to include the outdated and incomplete list of HTML attributes in the templates anymore. You can just set them via Python.

__Note:__ This attribute expansion does only work that way in Chameleon. Therefore we cannot change any of the templates in z3c.form because - I think - it needs to stay compatible with the Zope PageTemplates reference implementation.