### PR TITLE
DRAFT: Chameleon templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
 
 - Drop deprecated support for ``python setup.py test``.
 
+- HTMLFormElement.attributes: Allow to extend HTML attributes programmatically.
+
 
 4.3 (2022-03-24)
 ----------------

--- a/src/z3c/form/browser/button_input.pt
+++ b/src/z3c/form/browser/button_input.pt
@@ -1,30 +1,5 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<input type="button" id="" name="" class="" value="" accesskey=""
-       tal:attributes="id view/id;
-                       name view/name;
-                       class view/klass;
-                       style view/style;
-                       lang view/lang;
-                       onclick view/onclick;
-                       ondblclick view/ondblclick;
-                       onmousedown view/onmousedown;
-                       onmouseup view/onmouseup;
-                       onmouseover view/onmouseover;
-                       onmousemove view/onmousemove;
-                       onmouseout view/onmouseout;
-                       onkeypress view/onkeypress;
-                       onkeydown view/onkeydown;
-                       onkeyup view/onkeyup;
-                       value view/value;
-                       disabled view/disabled;
-                       tabindex view/tabindex;
-                       onfocus view/onfocus;
-                       onblur view/onblur;
-                       onchange view/onchange;
-                       readonly view/readonly;
-                       alt view/alt;
-                       accesskey view/accesskey;
-                       onselect view/onselect" />
+<input type="button" tal:attributes="view/attributes" />
 </html>

--- a/src/z3c/form/browser/checkbox_display.pt
+++ b/src/z3c/form/browser/checkbox_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<span id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
+<span tal:attributes="view/attributes"><tal:block
     repeat="value view/displayValue"
     ><span class="selected-option"
            tal:content="value"

--- a/src/z3c/form/browser/checkbox_hidden.pt
+++ b/src/z3c/form/browser/checkbox_hidden.pt
@@ -3,35 +3,9 @@
      tal:omit-tag="">
 <tal:repeat repeat="item view/items">
 <span class="option" tal:condition="item/checked">
-  <input id="" name="" value="" class="hidden-widget" title=""
-         tabindex="" accesskey=""
-         type="hidden"
-         tal:attributes="id item/id;
-                         name item/name;
-                         class view/klass;
-                         value item/value;
-                         style view/style;
-                         title view/title;
-                         lang view/lang;
-                         onclick view/onclick;
-                         ondblclick view/ondblclick;
-                         onmousedown view/onmousedown;
-                         onmouseup view/onmouseup;
-                         onmouseover view/onmouseover;
-                         onmousemove view/onmousemove;
-                         onmouseout view/onmouseout;
-                         onkeypress view/onkeypress;
-                         onkeydown view/onkeydown;
-                         onkeyup view/onkeyup;
-                         disabled view/disabled;
-                         tabindex view/tabindex;
-                         onfocus view/onfocus;
-                         onblur view/onblur;
-                         onchange view/onchange;
-                         readonly view/readonly;
-                         alt view/alt;
-                         accesskey view/accesskey;
-                         onselect view/onselect" />
+  <input type="hidden"
+         tal:attributes="view/attributes"
+         />
 </span>
 </tal:repeat>
 <input name="field-empty-marker" type="hidden" value="1"

--- a/src/z3c/form/browser/checkbox_input.pt
+++ b/src/z3c/form/browser/checkbox_input.pt
@@ -10,66 +10,10 @@
  <span class="option"
        tal:repeat="item items"
        tal:attributes="id python:single_checkbox and view.id or None">
-  <input type="checkbox" id="" name="" class="" alt="" title=""
-         tabindex="" disabled="" readonly="" accesskey="" value=""
-         checked="checked"
-         tal:condition="item/checked"
-         tal:attributes="id item/id;
-                         name item/name;
-                         class view/klass;
-                         value item/value;
-                         style view/style;
-                         title view/title;
-                         lang view/lang;
-                         onclick view/onclick;
-                         ondblclick view/ondblclick;
-                         onmousedown view/onmousedown;
-                         onmouseup view/onmouseup;
-                         onmouseover view/onmouseover;
-                         onmousemove view/onmousemove;
-                         onmouseout view/onmouseout;
-                         onkeypress view/onkeypress;
-                         onkeydown view/onkeydown;
-                         onkeyup view/onkeyup;
-                         disabled view/disabled;
-                         tabindex view/tabindex;
-                         onfocus view/onfocus;
-                         onblur view/onblur;
-                         onchange view/onchange;
-                         readonly view/readonly;
-                         alt view/alt;
-                         accesskey view/accesskey;
-                         onselect view/onselect"
-  /><input id="" name="" class="" alt="" title="" tabindex=""
-           disabled="" readonly="" accesskey="" value=""
-           type="checkbox"
-         tal:condition="not:item/checked"
-         tal:attributes="id item/id;
-                         name item/name;
-                         class view/klass;
-                         value item/value;
-                         style view/style;
-                         title view/title;
-                         lang view/lang;
-                         onclick view/onclick;
-                         ondblclick view/ondblclick;
-                         onmousedown view/onmousedown;
-                         onmouseup view/onmouseup;
-                         onmouseover view/onmouseover;
-                         onmousemove view/onmousemove;
-                         onmouseout view/onmouseout;
-                         onkeypress view/onkeypress;
-                         onkeydown view/onkeydown;
-                         onkeyup view/onkeyup;
-                         disabled view/disabled;
-                         tabindex view/tabindex;
-                         onfocus view/onfocus;
-                         onblur view/onblur;
-                         onchange view/onchange;
-                         readonly view/readonly;
-                         alt view/alt;
-                         accesskey view/accesskey;
-                         onselect view/onselect" />
+  <input type="checkbox"
+         checked="item/checked|nothing"
+         tal:attributes="view/attributes"
+  />
   <label for=""
          tal:attributes="for item/id">
     <span class="label" tal:content="item/label">Label</span>

--- a/src/z3c/form/browser/file_display.pt
+++ b/src/z3c/form/browser/file_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<span id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
+<span tal:attributes="view/attributes"><tal:block
       condition="view/value" content="view/value"
 /></span>
 </html>

--- a/src/z3c/form/browser/file_input.pt
+++ b/src/z3c/form/browser/file_input.pt
@@ -1,33 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<input type="file" id="" name="" class="" title="" lang="" disabled=""
-       readonly="" alt="" tabindex="" accesskey="" size="" maxlength=""
-       tal:attributes="id view/id;
-                       name view/name;
-                       class view/klass;
-                       style view/style;
-                       title view/title;
-                       lang view/lang;
-                       onclick view/onclick;
-                       ondblclick view/ondblclick;
-                       onmousedown view/onmousedown;
-                       onmouseup view/onmouseup;
-                       onmouseover view/onmouseover;
-                       onmousemove view/onmousemove;
-                       onmouseout view/onmouseout;
-                       onkeypress view/onkeypress;
-                       onkeydown view/onkeydown;
-                       onkeyup view/onkeyup;
-                       disabled view/disabled;
-                       tabindex view/tabindex;
-                       onfocus view/onfocus;
-                       onblur view/onblur;
-                       onchange view/onchange;
-                       readonly view/readonly;
-                       alt view/alt;
-                       accesskey view/accesskey;
-                       onselect view/onselect;
-                       size view/size;
-                       maxlength view/maxlength" />
+<input type="file"
+       tal:attributes="view/attributes"
+       />
 </html>

--- a/src/z3c/form/browser/file_testing_input.pt
+++ b/src/z3c/form/browser/file_testing_input.pt
@@ -1,36 +1,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<input type="file" id="" name="" class="" title="" lang="" disabled=""
-       readonly="" alt="" tabindex="" accesskey="" size="" maxlength=""
-       tal:attributes="id view/id;
-                       name view/name;
-                       class view/klass;
-                       style view/style;
-                       title view/title;
-                       lang view/lang;
-                       onclick view/onclick;
-                       ondblclick view/ondblclick;
-                       onmousedown view/onmousedown;
-                       onmouseup view/onmouseup;
-                       onmouseover view/onmouseover;
-                       onmousemove view/onmousemove;
-                       onmouseout view/onmouseout;
-                       onkeypress view/onkeypress;
-                       onkeydown view/onkeydown;
-                       onkeyup view/onkeyup;
-                       disabled view/disabled;
-                       tabindex view/tabindex;
-                       onfocus view/onfocus;
-                       onblur view/onblur;
-                       onchange view/onchange;
-                       readonly view/readonly;
-                       alt view/alt;
-                       accesskey view/accesskey;
-                       onselect view/onselect;
-                       size view/size;
-                       maxlength view/maxlength" />
-
+<input type="file"
+       tal:attributes="view/attributes"
+       />
 <input type="hidden" name=""
        tal:attributes="name string:${view/name}.encoding; value string:plain" />
 <textarea name="" style="display: none;"

--- a/src/z3c/form/browser/image_input.pt
+++ b/src/z3c/form/browser/image_input.pt
@@ -1,32 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<input id="" name="" class="" src="" value=""
-       accesskey="" type="image"
-       tal:attributes="id view/id;
-                       name view/name;
-                       class view/klass;
-                       style view/style;
-                       lang view/lang;
-                       onclick view/onclick;
-                       ondblclick view/ondblclick;
-                       onmousedown view/onmousedown;
-                       onmouseup view/onmouseup;
-                       onmouseover view/onmouseover;
-                       onmousemove view/onmousemove;
-                       onmouseout view/onmouseout;
-                       onkeypress view/onkeypress;
-                       onkeydown view/onkeydown;
-                       onkeyup view/onkeyup;
-                       src view/src;
-                       value view/value;
-                       disabled view/disabled;
-                       tabindex view/tabindex;
-                       onfocus view/onfocus;
-                       onblur view/onblur;
-                       onchange view/onchange;
-                       readonly view/readonly;
-                       alt view/alt;
-                       accesskey view/accesskey;
-                       onselect view/onselect" />
+<input type="image"
+       tal:attributes="view/attributes"
+       />
 </html>

--- a/src/z3c/form/browser/multi_display.pt
+++ b/src/z3c/form/browser/multi_display.pt
@@ -3,22 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       tal:omit-tag="">
-<div id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup">
+<div  tal:attributes="view/attributes">
   <tal:block repeat="widget view/widgets">
     <div id="" class="row"
          tal:attributes="id string:${widget/id}-row"

--- a/src/z3c/form/browser/orderedselect_display.pt
+++ b/src/z3c/form/browser/orderedselect_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<span id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
+<span tal:attributes="view/attributes"><tal:block
     repeat="value view/displayValue"
     ><span class="selected-option"
            tal:content="value"

--- a/src/z3c/form/browser/orderedselect_input.pt
+++ b/src/z3c/form/browser/orderedselect_input.pt
@@ -8,30 +8,7 @@
        tal:attributes="id view/id">
   <tr>
     <td>
-      <select id="from" name="from" class=""  multiple="" size="5"
-          tal:attributes="id string:${view/id}-from;
-                          name string:${view/name}.from;
-                          class view/klass;
-                          style view/style;
-                          title view/title;
-                          lang view/lang;
-                          onclick view/onclick;
-                          ondblclick view/ondblclick;
-                          onmousedown view/onmousedown;
-                          onmouseup view/onmouseup;
-                          onmouseover view/onmouseover;
-                          onmousemove view/onmousemove;
-                          onmouseout view/onmouseout;
-                          onkeypress view/onkeypress;
-                          onkeydown view/onkeydown;
-                          onkeyup view/onkeyup;
-                          disabled view/disabled;
-                          tabindex view/tabindex;
-                          onfocus view/onfocus;
-                          onblur view/onblur;
-                          onchange view/onchange;
-                          multiple view/multiple;
-                          size view/size">
+      <select id="from" name="from" tal:attributes="view/attributes">
         <option tal:repeat="entry view/notselectedItems"
                 tal:attributes="value entry/value"
                 tal:content="nocall:entry/content" i18n:translate=""/>
@@ -49,30 +26,7 @@
           >&larr;</button>
     </td>
     <td>
-      <select id="to" name="to" class="" multiple="" size="5"
-          tal:attributes="id string:${view/id}-to;
-                          name string:${view/name}.to;
-                          class view/klass;
-                          style view/style;
-                          title view/title;
-                          lang view/lang;
-                          onclick view/onclick;
-                          ondblclick view/ondblclick;
-                          onmousedown view/onmousedown;
-                          onmouseup view/onmouseup;
-                          onmouseover view/onmouseover;
-                          onmousemove view/onmousemove;
-                          onmouseout view/onmouseout;
-                          onkeypress view/onkeypress;
-                          onkeydown view/onkeydown;
-                          onkeyup view/onkeyup;
-                          disabled view/disabled;
-                          tabindex view/tabindex;
-                          onfocus view/onfocus;
-                          onblur view/onblur;
-                          onchange view/onchange;
-                          multiple view/multiple;
-                          size view/size">
+      <select id="to" name="to" class="" tal:attributes="view/attributes">
         <option tal:repeat="entry view/selectedItems"
                 tal:attributes="value entry/value"
                 tal:content="nocall:entry/content" i18n:translate=""/>

--- a/src/z3c/form/browser/password_display.pt
+++ b/src/z3c/form/browser/password_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<span id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
+<span tal:attributes="view/attributes"><tal:block
       condition="view/value" content="view/value"
 /></span>
 </html>

--- a/src/z3c/form/browser/password_input.pt
+++ b/src/z3c/form/browser/password_input.pt
@@ -1,36 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<input id="" name="" class="" title="" lang="" disabled=""
-       readonly="" alt="" tabindex="" accesskey="" size="" maxlength=""
-       type="password"
-       tal:attributes="id view/id;
-                       name view/name;
-                       class view/klass;
-                       style view/style;
-                       title view/title;
-                       lang view/lang;
-                       onclick view/onclick;
-                       ondblclick view/ondblclick;
-                       onmousedown view/onmousedown;
-                       onmouseup view/onmouseup;
-                       onmouseover view/onmouseover;
-                       onmousemove view/onmousemove;
-                       onmouseout view/onmouseout;
-                       onkeypress view/onkeypress;
-                       onkeydown view/onkeydown;
-                       onkeyup view/onkeyup;
-                       disabled view/disabled;
-                       tabindex view/tabindex;
-                       onfocus view/onfocus;
-                       onblur view/onblur;
-                       onchange view/onchange;
-                       readonly view/readonly;
-                       alt view/alt;
-                       accesskey view/accesskey;
-                       onselect view/onselect;
-                       size view/size;
-                       maxlength view/maxlength;
-                       placeholder view/placeholder;
-                       autocapitalize view/autocapitalize;" />
+<input type="password"
+       tal:attributes="view/attributes"
+       />
 </html>

--- a/src/z3c/form/browser/radio_display.pt
+++ b/src/z3c/form/browser/radio_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<span id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
+<span tal:attributes="view/attributes"><tal:block
     repeat="value view/displayValue"
     ><span class="selected-option"
            tal:content="value"

--- a/src/z3c/form/browser/radio_display_single.pt
+++ b/src/z3c/form/browser/radio_display_single.pt
@@ -2,23 +2,8 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:define="item python:args[0]"
       tal:omit-tag="">
-<span id="" class=""
-      tal:condition="python: item['value'] in view.value"
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
+<span tal:attributes="view/attributes"
+      tal:condition="python: item['value'] in view.value"><tal:block
     repeat="value view/displayValue"
     ><span class="selected-option"
            tal:content="value"

--- a/src/z3c/form/browser/radio_input_single.pt
+++ b/src/z3c/form/browser/radio_input_single.pt
@@ -2,36 +2,8 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:define="item python:args[0]"
       tal:omit-tag="">
-  <input id="" name="" class="" alt="" title=""
-         tabindex="" disabled="" readonly="" accesskey="" value=""
-         checked="" type="radio"
-         tal:define="checked item/checked"
-         tal:attributes="id item/id;
-                         name item/name;
-                         class view/klass;
-                         value item/value;
-                         style view/style;
-                         title view/title;
-                         lang view/lang;
-                         onclick view/onclick;
-                         ondblclick view/ondblclick;
-                         onmousedown view/onmousedown;
-                         onmouseup view/onmouseup;
-                         onmouseover view/onmouseover;
-                         onmousemove view/onmousemove;
-                         onmouseout view/onmouseout;
-                         onkeypress view/onkeypress;
-                         onkeydown view/onkeydown;
-                         onkeyup view/onkeyup;
-                         disabled view/disabled;
-                         tabindex view/tabindex;
-                         onfocus view/onfocus;
-                         onblur view/onblur;
-                         onchange view/onchange;
-                         readonly view/readonly;
-                         alt view/alt;
-                         accesskey view/accesskey;
-                         onselect view/onselect;
-                         checked python: checked and 'checked' or None"
+  <input type="radio"
+         checked="item/checked|nothing"
+         tal:attributes="view/attributes"
          />
 </html>

--- a/src/z3c/form/browser/select_display.pt
+++ b/src/z3c/form/browser/select_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<span id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
+<span tal:attributes="view/attributes"><tal:block
     repeat="value view/displayValue"
     ><span class="selected-option"
            tal:content="value"

--- a/src/z3c/form/browser/select_input.pt
+++ b/src/z3c/form/browser/select_input.pt
@@ -1,30 +1,7 @@
 <div xmlns="http://www.w3.org/1999/xhtml"
      xmlns:tal="http://xml.zope.org/namespaces/tal"
      tal:omit-tag="">
-<select id="" name="" class="" tabindex="" disabled="" multiple="" size=""
-        tal:attributes="id view/id;
-                        name string:${view/name}:list;
-                        class view/klass;
-                        style view/style;
-                        title view/title;
-                        lang view/lang;
-                        onclick view/onclick;
-                        ondblclick view/ondblclick;
-                        onmousedown view/onmousedown;
-                        onmouseup view/onmouseup;
-                        onmouseover view/onmouseover;
-                        onmousemove view/onmousemove;
-                        onmouseout view/onmouseout;
-                        onkeypress view/onkeypress;
-                        onkeydown view/onkeydown;
-                        onkeyup view/onkeyup;
-                        disabled view/disabled;
-                        tabindex view/tabindex;
-                        onfocus view/onfocus;
-                        onblur view/onblur;
-                        onchange view/onchange;
-                        multiple view/multiple;
-                        size view/size">
+<select tal:attributes="view/attributes">
 <tal:block repeat="item view/items"
   ><option id="" value="" selected="selected"
          tal:condition="item/selected"

--- a/src/z3c/form/browser/submit_input.pt
+++ b/src/z3c/form/browser/submit_input.pt
@@ -1,31 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<input id="" name="" class="" value=""
-       accesskey="" type="submit"
-       tal:attributes="id view/id;
-                       name view/name;
-                       class view/klass;
-                       style view/style;
-                       lang view/lang;
-                       onclick view/onclick;
-                       ondblclick view/ondblclick;
-                       onmousedown view/onmousedown;
-                       onmouseup view/onmouseup;
-                       onmouseover view/onmouseover;
-                       onmousemove view/onmousemove;
-                       onmouseout view/onmouseout;
-                       onkeypress view/onkeypress;
-                       onkeydown view/onkeydown;
-                       onkeyup view/onkeyup;
-                       value view/value;
-                       disabled view/disabled;
-                       tabindex view/tabindex;
-                       onfocus view/onfocus;
-                       onblur view/onblur;
-                       onchange view/onchange;
-                       readonly view/readonly;
-                       alt view/alt;
-                       accesskey view/accesskey;
-                       onselect view/onselect" />
+<input type="submit"
+       tal:attributes="view/attributes"
+       />
 </html>

--- a/src/z3c/form/browser/text_display.pt
+++ b/src/z3c/form/browser/text_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-    <span id="" class=""
-          tal:attributes="id view/id;
-                          class view/klass;
-                          style view/style;
-                          title view/title;
-                          lang view/lang;
-                          onclick view/onclick;
-                          ondblclick view/ondblclick;
-                          onmousedown view/onmousedown;
-                          onmouseup view/onmouseup;
-                          onmouseover view/onmouseover;
-                          onmousemove view/onmousemove;
-                          onmouseout view/onmouseout;
-                          onkeypress view/onkeypress;
-                          onkeydown view/onkeydown;
-                          onkeyup view/onkeyup"><tal:block
+    <span tal:attributes="view/attributes"><tal:block
           condition="view/value" content="view/value"
     /></span>
 </html>

--- a/src/z3c/form/browser/text_input.pt
+++ b/src/z3c/form/browser/text_input.pt
@@ -1,37 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-    <input id="" name="" class="" title="" lang="" disabled=""
-           readonly="" alt="" tabindex="" accesskey="" size="" maxlength=""
-           style="" value="" type="text"
-           tal:attributes="id view/id;
-                           name view/name;
-                           class view/klass;
-                           style view/style;
-                           title view/title;
-                           lang view/lang;
-                           onclick view/onclick;
-                           ondblclick view/ondblclick;
-                           onmousedown view/onmousedown;
-                           onmouseup view/onmouseup;
-                           onmouseover view/onmouseover;
-                           onmousemove view/onmousemove;
-                           onmouseout view/onmouseout;
-                           onkeypress view/onkeypress;
-                           onkeydown view/onkeydown;
-                           onkeyup view/onkeyup;
-                           value view/value;
-                           disabled view/disabled;
-                           tabindex view/tabindex;
-                           onfocus view/onfocus;
-                           onblur view/onblur;
-                           onchange view/onchange;
-                           readonly view/readonly;
-                           alt view/alt;
-                           accesskey view/accesskey;
-                           onselect view/onselect;
-                           size view/size;
-                           maxlength view/maxlength;
-                           placeholder view/placeholder;
-                           autocapitalize view/autocapitalize;" />
+    <input type="text"
+           tal:attributes="view/attributes"
+           />
 </html>

--- a/src/z3c/form/browser/textarea_display.pt
+++ b/src/z3c/form/browser/textarea_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-    <span id="" class=""
-          tal:attributes="id view/id;
-                          class view/klass;
-                          style view/style;
-                          title view/title;
-                          lang view/lang;
-                          onclick view/onclick;
-                          ondblclick view/ondblclick;
-                          onmousedown view/onmousedown;
-                          onmouseup view/onmouseup;
-                          onmouseover view/onmouseover;
-                          onmousemove view/onmousemove;
-                          onmouseout view/onmouseout;
-                          onkeypress view/onkeypress;
-                          onkeydown view/onkeydown;
-                          onkeyup view/onkeyup"><tal:block
+    <span tal:attributes="view/attributes"><tal:block
           condition="view/value" content="view/value"
     /></span>
 </html>

--- a/src/z3c/form/browser/textarea_input.pt
+++ b/src/z3c/form/browser/textarea_input.pt
@@ -1,34 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<textarea
-   id="" name="" class="" cols="" rows=""
-   tabindex="" disabled="" readonly="" accesskey=""
-   tal:attributes="id view/id;
-                   name view/name;
-                   class view/klass;
-                   style view/style;
-                   title view/title;
-                   lang view/lang;
-                   onclick view/onclick;
-                   ondblclick view/ondblclick;
-                   onmousedown view/onmousedown;
-                   onmouseup view/onmouseup;
-                   onmouseover view/onmouseover;
-                   onmousemove view/onmousemove;
-                   onmouseout view/onmouseout;
-                   onkeypress view/onkeypress;
-                   onkeydown view/onkeydown;
-                   onkeyup view/onkeyup;
-                   disabled view/disabled;
-                   tabindex view/tabindex;
-                   onfocus view/onfocus;
-                   onblur view/onblur;
-                   onchange view/onchange;
-                   cols view/cols;
-                   rows view/rows;
-                   readonly view/readonly;
-                   accesskey view/accesskey;
-                   onselect view/onselect"
-   tal:content="view/value" />
+<textarea tal:attributes="view/attributes"
+          tal:content="view/value"></textarea>
 </html>

--- a/src/z3c/form/browser/textlines_display.pt
+++ b/src/z3c/form/browser/textlines_display.pt
@@ -1,22 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<span id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
+<span tal:attributes="view/attributes"><tal:block
       condition="view/value" content="view/value"
 /></span>
 </html>

--- a/src/z3c/form/browser/textlines_input.pt
+++ b/src/z3c/form/browser/textlines_input.pt
@@ -1,34 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
-<textarea
-    id="" name="" class="" cols="" rows=""
-    tabindex="" disabled="" readonly="" accesskey=""
-    tal:attributes="id view/id;
-                    name view/name;
-                    class view/klass;
-                    style view/style;
-                    title view/title;
-                    lang view/lang;
-                    onclick view/onclick;
-                    ondblclick view/ondblclick;
-                    onmousedown view/onmousedown;
-                    onmouseup view/onmouseup;
-                    onmouseover view/onmouseover;
-                    onmousemove view/onmousemove;
-                    onmouseout view/onmouseout;
-                    onkeypress view/onkeypress;
-                    onkeydown view/onkeydown;
-                    onkeyup view/onkeyup;
-                    disabled view/disabled;
-                    tabindex view/tabindex;
-                    onfocus view/onfocus;
-                    onblur view/onblur;
-                    onchange view/onchange;
-                    cols view/cols;
-                    rows view/rows;
-                    readonly view/readonly;
-                    accesskey view/accesskey;
-                    onselect view/onselect"
+<textarea tal:attributes="view/attributes"
     tal:content="structure view/value" />
 </html>

--- a/src/z3c/form/browser/widget.py
+++ b/src/z3c/form/browser/widget.py
@@ -164,6 +164,58 @@ class HTMLFormElement(WidgetLayoutSupport):
         if self.mode == INPUT_MODE and self.required:
             self.addClass('required')
 
+    @property
+    def _html_attributes(self):
+        """Return a list of HTML attributes managed by this class."""
+        # This is basically a list of all the FieldProperty names except for
+        # the `css` property, which is not an HTML attribute.
+        return [
+            "id",
+            "klass",  # will be changed to `class`
+            "style",
+            "title",
+            "lang",
+            "onclick",
+            "ondblclick",
+            "onmousedown",
+            "onmouseup",
+            "onmouseover",
+            "onmousemove",
+            "onmouseout",
+            "onkeypress",
+            "onkeydown",
+            "onkeyup",
+            "disabled",
+            "tabindex",
+            "onfocus",
+            "onblur",
+            "onchange",
+        ]
+
+    _attributes = None
+
+    @property
+    def attributes(self) -> dict:
+        # If `attributes` were explicitly set, return them.
+        if isinstance(self._attributes, dict):
+            return self._attributes
+
+        # Otherwise return the default set of non-empty HTML attributes.
+        attributes_items = map(
+            lambda attr: (
+                attr if attr != "klass" else "class",
+                getattr(self, attr, None),
+            ),
+            self._html_attributes,
+        )
+        self._attributes = {key: val for key, val in attributes_items if val}
+        return self._attributes
+
+    @attributes.setter
+    def attributes(self, value: dict):
+        # Store the explicitly set attributes.
+        self._attributes = value
+
 
 @zope.interface.implementer(interfaces.IHTMLInputWidget)
 class HTMLInputWidget(HTMLFormElement):
@@ -172,6 +224,19 @@ class HTMLInputWidget(HTMLFormElement):
     alt = FieldProperty(interfaces.IHTMLInputWidget['alt'])
     accesskey = FieldProperty(interfaces.IHTMLInputWidget['accesskey'])
     onselect = FieldProperty(interfaces.IHTMLInputWidget['onselect'])
+
+    @property
+    def _html_attributes(self):
+        attributes = super()._html_attributes
+        attributes.extend(
+            [
+                "readonly",
+                "alt",
+                "accesskey",
+                "onselect",
+            ]
+        )
+        return attributes
 
 
 @zope.interface.implementer(interfaces.IHTMLTextInputWidget)
@@ -183,6 +248,19 @@ class HTMLTextInputWidget(HTMLInputWidget):
     autocapitalize = FieldProperty(
         interfaces.IHTMLTextInputWidget['autocapitalize'])
 
+    @property
+    def _html_attributes(self):
+        attributes = super()._html_attributes
+        attributes.extend(
+            [
+                "size",
+                "maxlength",
+                "placeholder",
+                "autocapitalize",
+            ]
+        )
+        return attributes
+
 
 @zope.interface.implementer(interfaces.IHTMLTextAreaWidget)
 class HTMLTextAreaWidget(HTMLFormElement):
@@ -193,12 +271,37 @@ class HTMLTextAreaWidget(HTMLFormElement):
     accesskey = FieldProperty(interfaces.IHTMLTextAreaWidget['accesskey'])
     onselect = FieldProperty(interfaces.IHTMLTextAreaWidget['onselect'])
 
+    @property
+    def _html_attributes(self):
+        attributes = super()._html_attributes
+        attributes.extend(
+            [
+                "rows",
+                "cols",
+                "readonly",
+                "accesskey",
+                "onselect",
+            ]
+        )
+        return attributes
+
 
 @zope.interface.implementer(interfaces.IHTMLSelectWidget)
 class HTMLSelectWidget(HTMLFormElement):
 
     multiple = FieldProperty(interfaces.IHTMLSelectWidget['multiple'])
     size = FieldProperty(interfaces.IHTMLSelectWidget['size'])
+
+    @property
+    def _html_attributes(self):
+        attributes = super()._html_attributes
+        attributes.extend(
+            [
+                "multiple",
+                "size",
+            ]
+        )
+        return attributes
 
 
 def addFieldClass(widget):

--- a/src/z3c/form/browser/widget.rst
+++ b/src/z3c/form/browser/widget.rst
@@ -1,0 +1,99 @@
+Widget base classes
+===================
+
+HTMLFormElement
+---------------
+The widget base class.
+::
+
+  >>> from z3c.form.browser.widget import HTMLFormElement
+  >>> form = HTMLFormElement()
+
+
+attributes
+..........
+
+On widgets you can programatically add, remove or modify HTML attributes::
+
+  >>> form = HTMLFormElement()
+  >>> form.id = "my-input"
+  >>> form.title = "This is my input."
+
+  >>> form.attributes
+  {'id': 'my-input', 'title': 'This is my input.'}
+
+
+Only attributes with values are included in :code:`attributes`::
+
+  >>> form = HTMLFormElement()
+  >>> form.id = "my-input"
+
+  >>> form.attributes
+  {'id': 'my-input'}
+
+
+The :code:`klass` attibute of the :code:`HTMLFormElement` is changed to :code:`class`::
+
+  >>> form = HTMLFormElement()
+  >>> form.klass = "class-a class-b"
+
+  >>> form.attributes
+  {'class': 'class-a class-b'}
+
+
+Once :code:`attributes` was accessed you cannot set the HTML attributes on the `HTMLFormElement` directly anymore::
+
+  >>> form = HTMLFormElement()
+  >>> form.id = "my-input"
+
+  >>> form.attributes
+  {'id': 'my-input'}
+
+  >>> form.id = "no-input"
+  >>> form.title = "This is my input."
+
+  >>> form.attributes
+  {'id': 'my-input'}
+
+
+But you can change them via the :code:`attributes` property::
+
+  >>> form = HTMLFormElement()
+  >>> form.id = "my-input"
+
+  >>> form.attributes
+  {'id': 'my-input'}
+
+  >>> form.attributes["id"] = "no-input"
+  >>> form.attributes["title"] = "Okay. No input then."
+
+  >>> form.attributes
+  {'id': 'no-input', 'title': 'Okay. No input then.'}
+
+  >>> form.attributes.update({"title": "The no input input.", "class": "class-a"})
+
+  >>> form.attributes
+  {'id': 'no-input', 'title': 'The no input input.', 'class': 'class-a'}
+
+You can delete items::
+
+  >>> del form.attributes["class"]
+  >>> form.attributes
+  {'id': 'no-input', 'title': 'The no input input.'}
+
+
+And directly set it anew::
+
+  >>> form.attributes = {'id': 'okay', 'title': 'I give up.'}
+  >>> form.attributes
+  {'id': 'okay', 'title': 'I give up.'}
+
+
+You can use attributes to render inputs in a generic way without explicitly including all the HTML attributes.
+
+Note: This only works if you use Chameleon templates. It does not work with the Zope PageTemplate reference implementation.
+
+This is how you would write your Chameleon template::
+
+  <input type="text" tal:attributes="view/attributes" />
+

--- a/src/z3c/form/tests/test_doc.py
+++ b/src/z3c/form/tests/test_doc.py
@@ -144,6 +144,11 @@ def test_suite():
             '../hint.rst',
             setUp=setUp, tearDown=testing.tearDown,
             optionflags=flags, checker=testing.outputChecker,
+        ),
+        doctest.DocFileSuite(
+            '../browser/widget.rst',
+            setUp=setUp, tearDown=testing.tearDown,
+            optionflags=flags, checker=testing.outputChecker,
         ))
         for setUp in setups)
 


### PR DESCRIPTION
This PR is only for reference and not meant to be merged.

A follow-up of https://github.com/zopefoundation/z3c.form/pull/116

Following the work in the mentioned PR above I changed all the templates to use attribute expansion like:

```
  <input type="text" tal:attributes="view/attributes" />
```

But this does only work with Chameleon, unless there is a trick to get it working in Zope's PageTemplate reference implementation.
