### PR TITLE
Don't set the boolean required attribute as required.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 5.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Don't set the boolean required attribute as required.
+  Boolean attributes with a default value which do not have to be set to true
+  should not be marked as required attributes.
 
 
 5.0 (2023-07-17)

--- a/src/z3c/form/interfaces.py
+++ b/src/z3c/form/interfaces.py
@@ -427,7 +427,7 @@ class IWidget(ILocation):
         description=_('If true the widget should be displayed as required '
                       'input.'),
         default=False,
-        required=True)
+        required=False)
 
     error = zope.schema.Field(
         title=_('Error'),


### PR DESCRIPTION
Boolean attributes with a default value which do not have to be set to true should not be marked as required attributes.